### PR TITLE
Issue #5: Fix unicode encoding compatiblity issue.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-Version 1.0.0
+Version 1.0.1
 
 Unified object oriented interface for interacting with file system
 objects. File system operations in python are distributed across

--- a/fswrap.py
+++ b/fswrap.py
@@ -30,6 +30,14 @@ PY3 = sys.version_info[0] == 3
 if PY3:
     unicode = str
 
+    def hash_update(hsh, chunk):
+        hsh.update(chunk.encode())
+
+else:
+    def hash_update(hsh, chunk):
+        hsh.update(chunk)
+
+
 
 class FS(object):
     """
@@ -317,7 +325,7 @@ class File(FS):
         with open(self.path) as fin:
             chunk = fin.read(CHUNKSIZE)
             while chunk:
-                hash.update(chunk.encode())
+                hash_update(hash, chunk)
                 chunk = fin.read(CHUNKSIZE)
         return hash.hexdigest()
 

--- a/setup.py
+++ b/setup.py
@@ -9,15 +9,15 @@ except IOError:
 
 setup(
     name='fswrap',
-    version='1.0.0',
-    author='Lakshmi Vyas',
-    author_email='lakshmi.vyas@gmail.com',
+    version='1.0.1',
+    author='fswrap contributors',
+    author_email='navilan@folds.in',
     url='http://github.com/hyde/fswrap',
     description='An opinionated wrapper on file system and path functions',
     long_description=long_description,
     license='MIT',
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Operating System :: OS Independent',

--- a/tests/test_fswrap.py
+++ b/tests/test_fswrap.py
@@ -213,9 +213,13 @@ def test_is_descendant_of():
 
 
 def test_get_relative_path():
-    assert INDEX.get_relative_path(ROOT_FOLDER) == Folder(AFOLDER.name).child(INDEX.name)
+    assert INDEX.get_relative_path(ROOT_FOLDER) == Folder(
+        AFOLDER.name).child(INDEX.name)
+
     assert INDEX.get_relative_path(ROOT_FOLDER.parent) == Folder(
-                        ROOT_FOLDER.name).child_folder(AFOLDER.name).child(INDEX.name)
+                        ROOT_FOLDER.name).child_folder(
+                            AFOLDER.name).child(INDEX.name)
+
     assert AFOLDER.get_relative_path(AFOLDER) == ""
 
 
@@ -223,7 +227,8 @@ def test_get_mirror():
     mirror = AFOLDER.get_mirror(DATA_ROOT, source_root=ROOT_FOLDER)
     assert mirror == DATA_ROOT.child_folder(AFOLDER.name)
     mirror = AFOLDER.get_mirror(DATA_ROOT, source_root=ROOT_FOLDER.parent)
-    assert mirror == DATA_ROOT.child_folder(ROOT_FOLDER.name).child_folder(AFOLDER.name)
+    assert mirror == DATA_ROOT.child_folder(
+        ROOT_FOLDER.name).child_folder(AFOLDER.name)
 
 
 def test_mimetype():
@@ -534,6 +539,17 @@ def test_etag_same():
     etag2 = f2.etag
     assert etag1 == etag2
     f3 = File.make_temp("I am new")
+    etag3 = f3.etag
+    assert etag1 == etag3
+
+
+def test_etag_unicode_same():
+    f1 = File.make_temp(u"\x80\x81")
+    etag1 = f1.etag
+    f2 = File(f1.path)
+    etag2 = f2.etag
+    assert etag1 == etag2
+    f3 = File.make_temp(u"\x80\x81")
     etag3 = f3.etag
     assert etag1 == etag3
 


### PR DESCRIPTION
Add a helper function to perform `hash.update`, conditionally
encoding the string when python 3.x is used.
